### PR TITLE
Templatize IBM QASM3 entrypoint and add context tests

### DIFF
--- a/qsg/adapters/ibm_qasm3.py
+++ b/qsg/adapters/ibm_qasm3.py
@@ -28,4 +28,4 @@ class IBMQasm3Adapter(Adapter):
             "payload_path": self.config.get("payload_path", "/app/payload/program.qasm"),
             "token_env": self.config.get("token_env", "IBM_TOKEN"),
         }
-        return Template(template_text).render(context)
+        return Template(template_text).render(**context)

--- a/qsg/adapters/ibm_qasm3.py
+++ b/qsg/adapters/ibm_qasm3.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+from jinja2 import Template
+
 from .base import Adapter
 
 class IBMQasm3Adapter(Adapter):
@@ -18,30 +21,11 @@ class IBMQasm3Adapter(Adapter):
         return ["qiskit", "qiskit-ibm-runtime", "qiskit_qasm3_import", "qiskit-aer"]
 
     def entrypoint(self) -> str:
-        # Uses IBM Token via env var IBM_TOKEN; runs a quick Sampler job
-        return r"""
-python - <<'PY'
-import os
-from qiskit_ibm_runtime import QiskitRuntimeService, Sampler
-from qiskit.qasm3 import loads
-
-qasm3 = open("/app/payload/program.qasm").read()
-qc = loads(qasm3)
-
-token = os.getenv("IBM_TOKEN")
-if not token:
-    print("No IBM_TOKEN env var found; running local simulation via qiskit instead.")
-    try:
-        from qiskit_aer.primitives import Sampler as LocalSampler
-    except ImportError:
-        # Fallback for older/newer path changes
-        from qiskit_ibm_runtime import Sampler as LocalSampler
-
-    sampler = LocalSampler()
-    print(sampler.run(qc).result())
-else:
-    service = QiskitRuntimeService(channel="ibm_quantum", token=token)
-    sampler = Sampler(session=None)
-    print(sampler.run(qc).result())
-PY
-"""
+        """Render the IBM Sampler wrapper with context."""
+        template_path = Path(__file__).parent / "templates" / "ibm_sampler.py.j2"
+        template_text = template_path.read_text()
+        context = {
+            "payload_path": self.config.get("payload_path", "/app/payload/program.qasm"),
+            "token_env": self.config.get("token_env", "IBM_TOKEN"),
+        }
+        return Template(template_text).render(context)

--- a/qsg/adapters/templates/ibm_sampler.py.j2
+++ b/qsg/adapters/templates/ibm_sampler.py.j2
@@ -1,0 +1,24 @@
+python - <<'PY'
+import os
+from qiskit_ibm_runtime import QiskitRuntimeService, Sampler
+from qiskit.qasm3 import loads
+
+qasm3 = open("{{ payload_path }}").read()
+qc = loads(qasm3)
+
+token = os.getenv("{{ token_env }}")
+if not token:
+    print("No {{ token_env }} env var found; running local simulation via qiskit instead.")
+    try:
+        from qiskit_aer.primitives import Sampler as LocalSampler
+    except ImportError:
+        # Fallback for older/newer path changes
+        from qiskit_ibm_runtime import Sampler as LocalSampler
+
+    sampler = LocalSampler()
+    print(sampler.run(qc).result())
+else:
+    service = QiskitRuntimeService(channel="ibm_quantum", token=token)
+    sampler = Sampler(session=None)
+    print(sampler.run(qc).result())
+PY

--- a/tests/test_ibm_adapter.py
+++ b/tests/test_ibm_adapter.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from qsg.adapters.ibm_qasm3 import IBMQasm3Adapter
+
+
+def test_entrypoint_default_context():
+    adapter = IBMQasm3Adapter()
+    entry = adapter.entrypoint()
+    assert "/app/payload/program.qasm" in entry
+    assert "IBM_TOKEN" in entry
+
+
+def test_entrypoint_custom_context():
+    adapter = IBMQasm3Adapter(payload_path="/tmp/foo.qasm", token_env="QISKIT_TOKEN")
+    entry = adapter.entrypoint()
+    assert "/tmp/foo.qasm" in entry
+    assert "QISKIT_TOKEN" in entry
+    assert "/app/payload/program.qasm" not in entry
+    assert "IBM_TOKEN" not in entry


### PR DESCRIPTION
## Summary
- Render IBM sampler wrapper using a Jinja template with context for payload path and token env var
- Replace hard-coded path/token in template with variables
- Add tests verifying entrypoint rendering for default and custom contexts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a1315d89c8333a2a5c9075cd6888e