### PR TITLE
Parameterize IBM sampler wrapper with render context

### DIFF
--- a/qsg/adapters/ibm_qasm3.py
+++ b/qsg/adapters/ibm_qasm3.py
@@ -21,4 +21,8 @@ class IBMQasm3Adapter(Adapter):
     def entrypoint(self) -> str:
         tpl_path = Path(__file__).parent / "templates" / "ibm_sampler.py.j2"
         template = Template(tpl_path.read_text())
-        return template.render()
+        context = {
+            "payload_path": self.config.get("payload_path", "/app/payload/program.qasm"),
+            "token_env_var": self.config.get("token_env_var", "IBM_TOKEN"),
+        }
+        return template.render(**context)

--- a/qsg/adapters/templates/ibm_sampler.py.j2
+++ b/qsg/adapters/templates/ibm_sampler.py.j2
@@ -2,12 +2,12 @@ import os
 from qiskit_ibm_runtime import QiskitRuntimeService, Sampler
 from qiskit.qasm3 import loads
 
-qasm3 = open("/app/payload/program.qasm").read()
+qasm3 = open("{{ payload_path }}").read()
 qc = loads(qasm3)
 
-token = os.getenv("IBM_TOKEN")
+token = os.getenv("{{ token_env_var }}")
 if not token:
-    print("No IBM_TOKEN env var found; running local simulation via qiskit instead.")
+    print("No {{ token_env_var }} env var found; running local simulation via qiskit instead.")
     try:
         from qiskit_aer.primitives import Sampler as LocalSampler
     except ImportError:

--- a/tests/test_ibm_adapter.py
+++ b/tests/test_ibm_adapter.py
@@ -1,0 +1,19 @@
+from qsg.adapters.ibm_qasm3 import IBMQasm3Adapter
+
+
+def test_entrypoint_uses_default_context():
+    adapter = IBMQasm3Adapter()
+    code = adapter.entrypoint()
+    assert '/app/payload/program.qasm' in code
+    assert 'os.getenv("IBM_TOKEN")' in code
+    assert 'No IBM_TOKEN env var found' in code
+
+
+def test_entrypoint_accepts_custom_context():
+    adapter = IBMQasm3Adapter(payload_path='/tmp/foo.qasm', token_env_var='MY_TOKEN')
+    code = adapter.entrypoint()
+    assert '/tmp/foo.qasm' in code
+    assert 'os.getenv("MY_TOKEN")' in code
+    assert 'No MY_TOKEN env var found' in code
+    assert '/app/payload/program.qasm' not in code
+    assert 'IBM_TOKEN' not in code


### PR DESCRIPTION
## Summary
- allow `IBMQasm3Adapter.entrypoint` to provide a context dict to the template
- template now accepts payload path and token env var instead of hard-coded values
- test that default and custom contexts render expected code

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a1628798c8333a17f0ee77870364d