### PR TITLE
Add template manager and adapter required field validation

### DIFF
--- a/qsg/adapters/ibm_qasm3.py
+++ b/qsg/adapters/ibm_qasm3.py
@@ -1,6 +1,5 @@
-from pathlib import Path
-from jinja2 import Template
 from .base import Adapter
+from .template_manager import render as render_template
 
 class IBMQasm3Adapter(Adapter):
     name = "ibm"
@@ -19,10 +18,12 @@ class IBMQasm3Adapter(Adapter):
         return ["qiskit", "qiskit-ibm-runtime", "qiskit_qasm3_import", "qiskit-aer"]
 
     def entrypoint(self) -> str:
-        tpl_path = Path(__file__).parent / "templates" / "ibm_sampler.py.j2"
-        template = Template(tpl_path.read_text())
         context = {
             "payload_path": self.config.get("payload_path", "/app/payload/program.qasm"),
             "token_env_var": self.config.get("token_env_var", "IBM_TOKEN"),
         }
-        return template.render(**context)
+        return render_template(
+            "ibm_sampler.py.j2",
+            context,
+            required_fields=["payload_path", "token_env_var"],
+        )

--- a/qsg/adapters/template_manager.py
+++ b/qsg/adapters/template_manager.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable
+
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+
+class TemplateManager:
+    """Shared Jinja2 environment for adapter templates."""
+
+    def __init__(self) -> None:
+        templates_dir = Path(__file__).parent / "templates"
+        # Use StrictUndefined so undefined variables raise an error during rendering
+        self.env = Environment(
+            loader=FileSystemLoader(str(templates_dir)),
+            undefined=StrictUndefined,
+        )
+
+    def render(
+        self,
+        template_name: str,
+        context: dict[str, Any],
+        required_fields: Iterable[str] | None = None,
+    ) -> str:
+        """Render a template with a context and required-field validation.
+
+        Args:
+            template_name: Name of the template file.
+            context: Variables to pass into the template.
+            required_fields: Iterable of keys that must exist and be truthy in the context.
+
+        Raises:
+            ValueError: If any required field is missing or falsy.
+            jinja2.TemplateNotFound: If the template is not found.
+        """
+        required_fields = required_fields or []
+        missing = [f for f in required_fields if not context.get(f)]
+        if missing:
+            raise ValueError(
+                f"Missing required fields for template '{template_name}': {', '.join(missing)}"
+            )
+        template = self.env.get_template(template_name)
+        return template.render(**context)
+
+
+# Singleton manager instance for module-level convenience
+_manager = TemplateManager()
+
+
+def render(
+    template_name: str, context: dict[str, Any], required_fields: Iterable[str] | None = None
+) -> str:
+    """Convenience function to render templates using the shared manager."""
+    return _manager.render(template_name, context, required_fields)

--- a/tests/test_ibm_adapter.py
+++ b/tests/test_ibm_adapter.py
@@ -1,4 +1,5 @@
 from qsg.adapters.ibm_qasm3 import IBMQasm3Adapter
+import pytest
 
 
 def test_entrypoint_uses_default_context():
@@ -17,3 +18,9 @@ def test_entrypoint_accepts_custom_context():
     assert 'No MY_TOKEN env var found' in code
     assert '/app/payload/program.qasm' not in code
     assert 'IBM_TOKEN' not in code
+
+
+def test_entrypoint_missing_required_field():
+    adapter = IBMQasm3Adapter(token_env_var=None)
+    with pytest.raises(ValueError):
+        adapter.entrypoint()


### PR DESCRIPTION
## Summary
- Add a shared Jinja2 TemplateManager with required-field checking
- Refactor IBM adapter to render through TemplateManager
- Test missing template variables raise errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a72be484483339a4c472eed47cd4c