### PR TITLE
feat: add adapter registry

### DIFF
--- a/qsg/adapters/__init__.py
+++ b/qsg/adapters/__init__.py
@@ -1,2 +1,11 @@
-from .base import load_adapter
-__all__ = ["load_adapter"]
+"""Adapter registration and loading utilities."""
+
+from .base import Adapter, load_adapter, register_adapter
+
+# Import built-in adapters so they register themselves via the decorator.
+from . import azure_qir  # noqa: F401
+from . import braket_qasm3  # noqa: F401
+from . import ibm_qasm3  # noqa: F401
+from . import rigetti_qir  # noqa: F401
+
+__all__ = ["Adapter", "load_adapter", "register_adapter"]

--- a/qsg/adapters/azure_qir.py
+++ b/qsg/adapters/azure_qir.py
@@ -1,5 +1,7 @@
-from .base import Adapter
+from .base import Adapter, register_adapter
 
+
+@register_adapter("azure")
 class AzureQIRAdapter(Adapter):
     name = "azure"
     def __init__(self, profile="base"):

--- a/qsg/adapters/base.py
+++ b/qsg/adapters/base.py
@@ -1,4 +1,19 @@
 from abc import ABC, abstractmethod
+from typing import Dict, Type
+
+
+ADAPTER_REGISTRY: Dict[str, Type["Adapter"]] = {}
+
+
+def register_adapter(name: str):
+    """Class decorator to register an adapter implementation."""
+
+    def _decorator(cls: Type["Adapter"]):
+        ADAPTER_REGISTRY[name] = cls
+        return cls
+
+    return _decorator
+
 
 class Adapter(ABC):
     name: str
@@ -19,17 +34,15 @@ class Adapter(ABC):
     def entrypoint(self) -> str:
         pass
 
+
 def load_adapter(target: str, **kwargs) -> "Adapter":
-    if target == "azure":
-        from .azure_qir import AzureQIRAdapter
-        return AzureQIRAdapter(**kwargs)
-    if target == "rigetti":
-        from .rigetti_qir import RigettiQIRAdapter
-        return RigettiQIRAdapter(**kwargs)
-    if target == "ibm":
-        from .ibm_qasm3 import IBMQasm3Adapter
-        return IBMQasm3Adapter(**kwargs)
-    if target == "braket":
-        from .braket_qasm3 import BraketQasm3Adapter
-        return BraketQasm3Adapter(**kwargs)
-    raise ValueError(f"Unknown target: {target}")
+    """Instantiate a registered adapter for ``target``.
+
+    Adapters register themselves via :func:`register_adapter`.
+    """
+
+    try:
+        adapter_cls = ADAPTER_REGISTRY[target]
+    except KeyError as exc:
+        raise ValueError(f"Unknown target: {target}") from exc
+    return adapter_cls(**kwargs)

--- a/qsg/adapters/braket_qasm3.py
+++ b/qsg/adapters/braket_qasm3.py
@@ -1,5 +1,7 @@
-from .base import Adapter
+from .base import Adapter, register_adapter
 
+
+@register_adapter("braket")
 class BraketQasm3Adapter(Adapter):
     name = "braket"
 

--- a/qsg/adapters/ibm_qasm3.py
+++ b/qsg/adapters/ibm_qasm3.py
@@ -1,6 +1,8 @@
-from .base import Adapter
+from .base import Adapter, register_adapter
 from .template_manager import render as render_template
 
+
+@register_adapter("ibm")
 class IBMQasm3Adapter(Adapter):
     name = "ibm"
 

--- a/qsg/adapters/rigetti_qir.py
+++ b/qsg/adapters/rigetti_qir.py
@@ -1,5 +1,7 @@
-from .base import Adapter
+from .base import Adapter, register_adapter
 
+
+@register_adapter("rigetti")
 class RigettiQIRAdapter(Adapter):
     name = "rigetti"
 

--- a/tests/test_adapter_registry.py
+++ b/tests/test_adapter_registry.py
@@ -1,0 +1,26 @@
+from qsg.adapters import Adapter, load_adapter, register_adapter
+
+
+def test_load_existing_adapter():
+    adapter = load_adapter("ibm")
+    from qsg.adapters.ibm_qasm3 import IBMQasm3Adapter
+    assert isinstance(adapter, IBMQasm3Adapter)
+
+
+def test_register_new_adapter():
+    @register_adapter("dummy")
+    class DummyAdapter(Adapter):
+        def required_ir(self) -> str:
+            return "noop"
+
+        def prepare_payload(self, ir_artifact) -> dict:
+            return {}
+
+        def runtime_packages(self) -> list[str]:
+            return []
+
+        def entrypoint(self) -> str:
+            return ""
+
+    adapter = load_adapter("dummy")
+    assert isinstance(adapter, DummyAdapter)


### PR DESCRIPTION
## Summary
- add registry and decorator for adapters
- register built-in adapters with decorator
- allow external adapters to self-register and load dynamically

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ba4cb814c8333826ea978936ffa0b