### PR TITLE
feat(cli): allow env vars in run-local

### DIFF
--- a/qsg/adapters/templates/ibm_sampler.py.j2
+++ b/qsg/adapters/templates/ibm_sampler.py.j2
@@ -15,6 +15,6 @@ if not token:
     sampler = LocalSampler()
     print(sampler.run(qc).result())
 else:
-    service = QiskitRuntimeService(channel="ibm_quantum", token=token)
+    service = QiskitRuntimeService(channel="ibm_quantum_platform", token=token)
     sampler = Sampler(session=None)
     print(sampler.run(qc).result())

--- a/qsg/cli.py
+++ b/qsg/cli.py
@@ -1,5 +1,8 @@
 from pathlib import Path
+from typing import List
+
 import typer
+
 from qsg.ir.lower import lower_to_ir
 from qsg.adapters import base as adapters_base
 from qsg.container.docker import build_image
@@ -38,11 +41,23 @@ def build(
     typer.echo(f"Built {tag}")
 
 @app.command()
-def run_local(image: str):
+def run_local(
+    image: str,
+    env: List[str] = typer.Option(
+        None,
+        "--env",
+        "-e",
+        help="Environment variables in KEY=VALUE format.",
+    ),
+):
     """Run the container locally for a smoke test (simulated)."""
     import docker
+
     client = docker.from_env()
-    logs = client.containers.run(image, detach=False, remove=True)
+    env_dict = dict(item.split("=", 1) for item in env) if env else None
+    logs = client.containers.run(
+        image, detach=False, remove=True, environment=env_dict
+    )
     print(logs.decode() if isinstance(logs, (bytes, bytearray)) else logs)
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
 from typer.testing import CliRunner
 from qsg import cli
+import sys
+from types import SimpleNamespace
 
 
 class DummyAdapter:
@@ -58,3 +60,23 @@ def test_build_requires_target(monkeypatch, tmp_path):
     runner = CliRunner()
     result = runner.invoke(cli.app, ['build', str(src)])
     assert result.exit_code != 0
+
+
+def test_run_local_with_env(monkeypatch):
+    captured = {}
+
+    def dummy_run(image, detach=False, remove=True, environment=None):
+        captured['env'] = environment
+        return b''
+
+    dummy_client = SimpleNamespace(containers=SimpleNamespace(run=dummy_run))
+    fake_docker = SimpleNamespace(from_env=lambda: dummy_client)
+    monkeypatch.setitem(sys.modules, 'docker', fake_docker)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        ['run-local', 'img', '-e', 'IBM_TOKEN=foo', '-e', 'X=Y'],
+    )
+    assert result.exit_code == 0
+    assert captured['env'] == {'IBM_TOKEN': 'foo', 'X': 'Y'}


### PR DESCRIPTION
## Summary
- allow passing environment variables to `run-local` via repeated `-e/--env` flags
- test `run-local` to ensure environment variables are forwarded to Docker

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e7346e5488333bbecac3d9f7eea11