### PR TITLE
Capture measurement counts for quantum backends

### DIFF
--- a/tools/runner.py
+++ b/tools/runner.py
@@ -45,6 +45,15 @@ def build_image(exp_py, tag, target, env_vars):
     build_env.update(env_vars or {})
     run(["qsg", "build", exp_py, "-t", target, "-i", tag], env=build_env)
 
+def image_exists(tag: str) -> bool:
+    """Return True if a Docker image with the given tag already exists."""
+    cp = subprocess.run(
+        ["docker", "image", "inspect", tag],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return cp.returncode == 0
+
 def docker_run(tag, env=None):
     env_opts = []
     if env:
@@ -74,6 +83,8 @@ def main():
     ap.add_argument("--modes", nargs="+", choices=["classical","aer","ibm"], required=True)
     ap.add_argument("--image-prefix", default="qsg/exp")
     ap.add_argument("--csv", default="results.csv")
+    ap.add_argument("--rebuild", action="store_true",
+                    help="Force rebuild of Docker images even if they already exist")
     args = ap.parse_args()
 
     exp_file = f"examples/{args.exp}_qiskit.py"
@@ -105,9 +116,12 @@ def main():
         # Aer (local) via IBM adapter (no token)
         if "aer" in args.modes:
             tag = f"{args.image_prefix}:{args.exp}-aer-n{n}"
-            t0 = time.time()
-            build_image(exp_file, tag, target="ibm", env_vars=params)
-            build_s = time.time() - t0
+            if args.rebuild or not image_exists(tag):
+                t0 = time.time()
+                build_image(exp_file, tag, target="ibm", env_vars=params)
+                build_s = time.time() - t0
+            else:
+                build_s = 0.0
             data = docker_run(tag, env={})  # no token
             counts = data.get("counts")
 
@@ -129,9 +143,12 @@ def main():
                 print("[WARN] IBM mode requested but IBM_TOKEN not set; skipping.")
             else:
                 tag = f"{args.image_prefix}:{args.exp}-ibm-n{n}"
-                t0 = time.time()
-                build_image(exp_file, tag, target="ibm", env_vars=params)
-                build_s = time.time() - t0
+                if args.rebuild or not image_exists(tag):
+                    t0 = time.time()
+                    build_image(exp_file, tag, target="ibm", env_vars=params)
+                    build_s = time.time() - t0
+                else:
+                    build_s = 0.0
                 data = docker_run(tag, env={"IBM_TOKEN": token})
                 counts = data.get("counts")
                 top_dec, top_p, big_endian = parse_quantum_counts(data, n)

--- a/tools/runner.py
+++ b/tools/runner.py
@@ -122,6 +122,7 @@ def main():
                 build_s = time.time() - t0
             else:
                 build_s = 0.0
+                print(f"Reuse {tag}")
             data = docker_run(tag, env={})  # no token
             counts = data.get("counts")
 
@@ -149,6 +150,7 @@ def main():
                     build_s = time.time() - t0
                 else:
                     build_s = 0.0
+                    print(f"Reuse {tag}")
                 data = docker_run(tag, env={"IBM_TOKEN": token})
                 counts = data.get("counts")
                 top_dec, top_p, big_endian = parse_quantum_counts(data, n)

--- a/tools/runner.py
+++ b/tools/runner.py
@@ -99,6 +99,7 @@ def main():
                 "build_s": 0.0, "submit_to_result_s": res["elapsed_s"],
                 "oracle_or_circuits": res["oracle_calls"], "success_prob": 1.0,
                 "note": res["note"],
+                "counts": None,
             })
 
         # Aer (local) via IBM adapter (no token)
@@ -108,6 +109,7 @@ def main():
             build_image(exp_file, tag, target="ibm", env_vars=params)
             build_s = time.time() - t0
             data = docker_run(tag, env={})  # no token
+            counts = data.get("counts")
 
             top_dec, top_p, big_endian = parse_quantum_counts(data, n)
             rows.append({
@@ -117,6 +119,7 @@ def main():
                 "oracle_or_circuits": 1 if args.exp=="bv" else int((3.14159/4) * (2**(n/2))),  # Grover iteration estimate
                 "success_prob": top_p,
                 "note": f'solution_be={big_endian}',  # big-endian bitstring to compare to marked
+                "counts": json.dumps(counts) if counts else None,
             })
 
         # IBM Runtime simulator (needs token)
@@ -130,6 +133,7 @@ def main():
                 build_image(exp_file, tag, target="ibm", env_vars=params)
                 build_s = time.time() - t0
                 data = docker_run(tag, env={"IBM_TOKEN": token})
+                counts = data.get("counts")
                 top_dec, top_p, big_endian = parse_quantum_counts(data, n)
                 rows.append({
                     "exp": args.exp, "n": n, "backend": "aer_local",
@@ -138,11 +142,12 @@ def main():
                     "oracle_or_circuits": 1 if args.exp=="bv" else int((3.14159/4) * (2**(n/2))),  # Grover iteration estimate
                     "success_prob": top_p,
                     "note": f'solution_be={big_endian}',  # big-endian bitstring to compare to marked
+                    "counts": json.dumps(counts) if counts else None,
                 })
 
     with open(args.csv, "w", newline="") as f:
         w = csv.DictWriter(f, fieldnames=[
-            "exp","n","backend","build_s","submit_to_result_s","oracle_or_circuits","success_prob","note"
+            "exp","n","backend","build_s","submit_to_result_s","oracle_or_circuits","success_prob","note","counts"
         ])
         w.writeheader(); w.writerows(rows)
     print("Wrote", args.csv)


### PR DESCRIPTION
## Summary
- capture raw measurement counts after each quantum backend run
- store counts JSON in results rows and CSV header

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a500d5c80c8333954826d5fdfe574c