### PR TITLE
Handle qsg run-local failures

### DIFF
--- a/tools/runner.py
+++ b/tools/runner.py
@@ -81,7 +81,12 @@ def qgen_local_run(tag, env=None):
     if env:
         for k,v in env.items():
             env_opts += ["-e", f"{k}={v}"]
-    cp = run(["qsg", "run-local"] + env_opts + [tag])
+    try:
+        cp = run(["qsg", "run-local"] + env_opts + [tag])
+    except subprocess.CalledProcessError as e:
+        print(e.stdout)
+        print(e.stderr)
+        raise
     out = cp.stdout.strip()
     try:
         data = json.loads(out.splitlines()[-1])


### PR DESCRIPTION
## Summary
- show stdout and stderr when `qsg run-local` fails in `qgen_local_run`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6815d8e9c83338eea62bbeb92e5ce