### PR TITLE
Add Google Cirq adapter

### DIFF
--- a/qsg/adapters/base.py
+++ b/qsg/adapters/base.py
@@ -32,4 +32,7 @@ def load_adapter(target: str, **kwargs) -> "Adapter":
     if target == "braket":
         from .braket_qasm3 import BraketQasm3Adapter
         return BraketQasm3Adapter(**kwargs)
+    if target == "google":
+        from .google_cirq import GoogleCirqAdapter
+        return GoogleCirqAdapter(**kwargs)
     raise ValueError(f"Unknown target: {target}")

--- a/qsg/adapters/google_cirq.py
+++ b/qsg/adapters/google_cirq.py
@@ -1,0 +1,30 @@
+from .base import Adapter
+from .template_manager import render as render_template
+
+
+class GoogleCirqAdapter(Adapter):
+    name = "google"
+
+    def __init__(self, **kwargs):
+        # Store kwargs if needed, or just accept them to avoid errors
+        self.config = kwargs
+
+    def required_ir(self) -> str:
+        return "qasm3"
+
+    def prepare_payload(self, ir_artifact) -> dict:
+        return ir_artifact
+
+    def runtime_packages(self) -> list[str]:
+        return ["cirq", "cirq-google"]
+
+    def entrypoint(self) -> str:
+        context = {
+            "payload_path": self.config.get("payload_path", "/app/payload/program.qasm"),
+            "project_id_env_var": self.config.get("project_id_env_var", "GOOGLE_PROJECT_ID"),
+        }
+        return render_template(
+            "google_submit.py.j2",
+            context,
+            required_fields=["payload_path", "project_id_env_var"],
+        )

--- a/qsg/adapters/templates/google_submit.py.j2
+++ b/qsg/adapters/templates/google_submit.py.j2
@@ -1,0 +1,16 @@
+import os
+import cirq
+import cirq_google as cg
+
+payload_path = "{{ payload_path }}"
+project_id = os.getenv("{{ project_id_env_var }}")
+if project_id is None:
+    raise EnvironmentError("No {{ project_id_env_var }} env var found")
+
+with open(payload_path, "r") as f:
+    qasm = f.read()
+
+circuit = cirq.circuit_from_qasm(qasm)
+engine = cg.Engine(project_id=project_id)
+result = engine.run(circuit)
+print(result)

--- a/tests/test_google_adapter.py
+++ b/tests/test_google_adapter.py
@@ -1,0 +1,39 @@
+from qsg.adapters import load_adapter
+from qsg.adapters.google_cirq import GoogleCirqAdapter
+import pytest
+
+
+def test_adapter_loading():
+    adapter = load_adapter("google")
+    assert isinstance(adapter, GoogleCirqAdapter)
+
+
+def test_entrypoint_uses_default_context():
+    adapter = GoogleCirqAdapter()
+    code = adapter.entrypoint()
+    assert '/app/payload/program.qasm' in code
+    assert 'os.getenv("GOOGLE_PROJECT_ID")' in code
+    assert 'No GOOGLE_PROJECT_ID env var found' in code
+
+
+def test_entrypoint_accepts_custom_context():
+    adapter = GoogleCirqAdapter(payload_path='/tmp/foo.qasm', project_id_env_var='MY_GOOGLE_PROJECT')
+    code = adapter.entrypoint()
+    assert '/tmp/foo.qasm' in code
+    assert 'os.getenv("MY_GOOGLE_PROJECT")' in code
+    assert 'No MY_GOOGLE_PROJECT env var found' in code
+    assert '/app/payload/program.qasm' not in code
+    assert 'GOOGLE_PROJECT_ID' not in code
+
+
+def test_entrypoint_missing_required_field():
+    adapter = GoogleCirqAdapter(project_id_env_var=None)
+    with pytest.raises(ValueError):
+        adapter.entrypoint()
+
+
+def test_runtime_packages():
+    adapter = GoogleCirqAdapter()
+    packages = adapter.runtime_packages()
+    assert 'cirq' in packages
+    assert 'cirq-google' in packages


### PR DESCRIPTION
## Summary
- add GoogleCirqAdapter for Google Quantum AI
- implement Cirq submission template
- load `google` target in adapter base and test runtime packages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a91e2adbf483339c11cb8d58e1a2dc