### PR TITLE
Add Azure Quantum adapter template and tests

### DIFF
--- a/examples/tsp8_qiskit.py
+++ b/examples/tsp8_qiskit.py
@@ -82,6 +82,8 @@ def build_circuit():
 
     # Draw
     # qc.draw()
+
+    qc.name = "main"
     return qc
 
 

--- a/examples/tsp8_qiskit.py
+++ b/examples/tsp8_qiskit.py
@@ -46,7 +46,7 @@ def build_circuit():
     unit = QuantumRegister(6, 'unit')
     eigen = QuantumRegister(8, 'eigen')
     unit_classical = ClassicalRegister(6, 'unit_classical')
-    qc = QuantumCircuit(unit, eigen, unit_classical)
+    qc = QuantumCircuit(unit, eigen, unit_classical, name="main")
     #
 
     # Setting one eigenstate 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
   "jinja2>=3.1",
   "docker>=7.0",
   "qiskit>=1.0",
+  "qiskit-qir>=0.5",
   "cirq-core>=1.3",
   "qiskit-ibm-runtime>=0.25",
   "pyyaml>=6.0",

--- a/qsg/adapters/azure_qir.py
+++ b/qsg/adapters/azure_qir.py
@@ -21,7 +21,7 @@ class AzureQIRAdapter(Adapter):
     def entrypoint(self) -> str:
         context = {
             "payload_path": self.config.get("payload_path", "/app/payload/program.ll"),
-            "target": self.config.get("target", "quantinuum.sim.h1-1sc"),
+            "target": self.config.get("target", "rigetti.sim.qvm"),
         }
         return render_template(
             "azure_submit.py.j2",

--- a/qsg/adapters/azure_qir.py
+++ b/qsg/adapters/azure_qir.py
@@ -20,7 +20,7 @@ class AzureQIRAdapter(Adapter):
 
     def entrypoint(self) -> str:
         context = {
-            "payload_path": self.config.get("payload_path", "/app/payload/program.bc"),
+            "payload_path": self.config.get("payload_path", "/app/payload/program.ll"),
             "target": self.config.get("target", "quantinuum.sim.h1-1sc"),
         }
         return render_template(

--- a/qsg/adapters/azure_qir.py
+++ b/qsg/adapters/azure_qir.py
@@ -1,9 +1,12 @@
 from .base import Adapter
+from .template_manager import render as render_template
 
 class AzureQIRAdapter(Adapter):
     name = "azure"
-    def __init__(self, profile="base"):
+
+    def __init__(self, profile="base", **kwargs):
         self.profile = profile
+        self.config = kwargs
 
     def required_ir(self) -> str:
         return "qir"
@@ -13,12 +16,15 @@ class AzureQIRAdapter(Adapter):
         return ir_artifact
 
     def runtime_packages(self) -> list[str]:
-        return ["azure-quantum"]
+        return ["azure-quantum", "azure-identity"]
 
     def entrypoint(self) -> str:
-        # Placeholder submission
-        return r"""
-python - <<'PY'
-print("Submitting QIR job to Azure... (stub)")
-PY
-"""
+        context = {
+            "payload_path": self.config.get("payload_path", "/app/payload/program.bc"),
+            "target": self.config.get("target", "microsoft.qpu"),
+        }
+        return render_template(
+            "azure_submit.py.j2",
+            context,
+            required_fields=["payload_path", "target"],
+        )

--- a/qsg/adapters/azure_qir.py
+++ b/qsg/adapters/azure_qir.py
@@ -21,7 +21,7 @@ class AzureQIRAdapter(Adapter):
     def entrypoint(self) -> str:
         context = {
             "payload_path": self.config.get("payload_path", "/app/payload/program.bc"),
-            "target": self.config.get("target", "microsoft.qpu"),
+            "target": self.config.get("target", "quantinuum.sim.h1-1sc"),
         }
         return render_template(
             "azure_submit.py.j2",

--- a/qsg/adapters/azure_qir.py
+++ b/qsg/adapters/azure_qir.py
@@ -16,7 +16,7 @@ class AzureQIRAdapter(Adapter):
         return ir_artifact
 
     def runtime_packages(self) -> list[str]:
-        return ["azure-quantum", "azure-identity"]
+        return ["azure-quantum", "azure-identity", "qiskit_qir"]
 
     def entrypoint(self) -> str:
         context = {

--- a/qsg/adapters/templates/azure_submit.py.j2
+++ b/qsg/adapters/templates/azure_submit.py.j2
@@ -19,8 +19,7 @@ workspace = Workspace(
     resource_group=resource_group,
     name=workspace_name,
     location=location,
-    credential=credential,
-    api_key=api_key
+    credential=credential
 )
 
 with open("{{ payload_path }}", "rb") as f:

--- a/qsg/adapters/templates/azure_submit.py.j2
+++ b/qsg/adapters/templates/azure_submit.py.j2
@@ -27,5 +27,4 @@ print("Submitted job:", job.id)
 
 job.wait_until_completed()
 result = job.get_results()
-print(f"Job status: {job.status}")
 print(f"Job result: {result}")

--- a/qsg/adapters/templates/azure_submit.py.j2
+++ b/qsg/adapters/templates/azure_submit.py.j2
@@ -6,8 +6,9 @@ subscription_id = os.getenv("AZURE_QUANTUM_SUBSCRIPTION_ID")
 resource_group = os.getenv("AZURE_QUANTUM_RESOURCE_GROUP")
 workspace_name = os.getenv("AZURE_QUANTUM_WORKSPACE_NAME")
 location = os.getenv("AZURE_QUANTUM_LOCATION")
+api_key = os.getenv("AZURE_QUANTUM_API_KEY")
 
-if not all([subscription_id, resource_group, workspace_name, location]):
+if not all([subscription_id, resource_group, workspace_name, location, api_key]):
     raise RuntimeError(
         "Missing Azure Quantum workspace configuration environment variables"
     )
@@ -19,6 +20,7 @@ workspace = Workspace(
     name=workspace_name,
     location=location,
     credential=credential,
+    api_key=api_key
 )
 
 with open("{{ payload_path }}", "rb") as f:

--- a/qsg/adapters/templates/azure_submit.py.j2
+++ b/qsg/adapters/templates/azure_submit.py.j2
@@ -21,6 +21,6 @@ job = target.submit(
     input_data_format="qir.v1",
     output_data_format="microsoft.quantum-results.v1",
     name="my-qir-job",
-    input_params={"entryPoint": "ENTRYPOINT__main", "arguments": [], "count": 8192},
+    input_params={"entryPoint": "ENTRYPOINT__main", "arguments": [], "shots": 8192},
 )
 print("Submitted job:", job.id)

--- a/qsg/adapters/templates/azure_submit.py.j2
+++ b/qsg/adapters/templates/azure_submit.py.j2
@@ -1,6 +1,6 @@
 import os
 from azure.quantum import Workspace
-from azure.identity import DefaultAzureCredential
+
 
 
 connection_string = os.getenv("CONNECTION_STRING")
@@ -10,12 +10,17 @@ if not all([connection_string]):
         "Missing Azure Quantum workspace configuration environment variables"
     )
 
-credential = DefaultAzureCredential()
 workspace = Workspace.from_connection_string(str(connection_string))
 
 with open("{{ payload_path }}", "rb") as f:
     program = f.read()
 
-job = workspace.submit(input_data=program, target="{{ target }}")
-print(f"Submitted job: {job.id}")
-
+target = workspace.get_targets(name="{{ target }}")  # e.g., "ionq.simulator"
+job = target.submit(
+    input_data=program,
+    input_data_format="qir.v1",
+    output_data_format="microsoft.quantum-results.v1",
+    name="my-qir-job",
+    input_params={"entryPoint": "ENTRYPOINT__main", "arguments": [], "count": 8192},
+)
+print("Submitted job:", job.id)

--- a/qsg/adapters/templates/azure_submit.py.j2
+++ b/qsg/adapters/templates/azure_submit.py.j2
@@ -1,0 +1,29 @@
+import os
+from azure.quantum import Workspace
+from azure.identity import DefaultAzureCredential
+
+subscription_id = os.getenv("AZURE_QUANTUM_SUBSCRIPTION_ID")
+resource_group = os.getenv("AZURE_QUANTUM_RESOURCE_GROUP")
+workspace_name = os.getenv("AZURE_QUANTUM_WORKSPACE_NAME")
+location = os.getenv("AZURE_QUANTUM_LOCATION")
+
+if not all([subscription_id, resource_group, workspace_name, location]):
+    raise RuntimeError(
+        "Missing Azure Quantum workspace configuration environment variables"
+    )
+
+credential = DefaultAzureCredential()
+workspace = Workspace(
+    subscription_id=subscription_id,
+    resource_group=resource_group,
+    name=workspace_name,
+    location=location,
+    credential=credential,
+)
+
+with open("{{ payload_path }}", "rb") as f:
+    program = f.read()
+
+job = workspace.submit(input_data=program, target="{{ target }}")
+print(f"Submitted job: {job.id}")
+

--- a/qsg/adapters/templates/azure_submit.py.j2
+++ b/qsg/adapters/templates/azure_submit.py.j2
@@ -5,7 +5,7 @@ from azure.identity import DefaultAzureCredential
 
 connection_string = os.getenv("CONNECTION_STRING")
 
-if not all([CONNECTION_STRING]):
+if not all([connection_string]):
     raise RuntimeError(
         "Missing Azure Quantum workspace configuration environment variables"
     )

--- a/qsg/adapters/templates/azure_submit.py.j2
+++ b/qsg/adapters/templates/azure_submit.py.j2
@@ -2,25 +2,16 @@ import os
 from azure.quantum import Workspace
 from azure.identity import DefaultAzureCredential
 
-subscription_id = os.getenv("AZURE_QUANTUM_SUBSCRIPTION_ID")
-resource_group = os.getenv("AZURE_QUANTUM_RESOURCE_GROUP")
-workspace_name = os.getenv("AZURE_QUANTUM_WORKSPACE_NAME")
-location = os.getenv("AZURE_QUANTUM_LOCATION")
-api_key = os.getenv("AZURE_QUANTUM_API_KEY")
 
-if not all([subscription_id, resource_group, workspace_name, location, api_key]):
+connection_string = os.getenv("CONNECTION_STRING")
+
+if not all([CONNECTION_STRING]):
     raise RuntimeError(
         "Missing Azure Quantum workspace configuration environment variables"
     )
 
 credential = DefaultAzureCredential()
-workspace = Workspace(
-    subscription_id=subscription_id,
-    resource_group=resource_group,
-    name=workspace_name,
-    location=location,
-    credential=credential
-)
+workspace = Workspace.from_connection_string(str(connection_string))
 
 with open("{{ payload_path }}", "rb") as f:
     program = f.read()

--- a/qsg/adapters/templates/azure_submit.py.j2
+++ b/qsg/adapters/templates/azure_submit.py.j2
@@ -21,7 +21,7 @@ job = target.submit(
     input_data_format="qir.v1",
     output_data_format="microsoft.quantum-results.v1",
     name="my-qir-job",
-    input_params={"entryPoint": "ENTRYPOINT__main", "arguments": [], "shots": 8192},
+    input_params={"entryPoint": "main", "arguments": [], "shots": 8192},
 )
 print("Submitted job:", job.id)
 

--- a/qsg/adapters/templates/azure_submit.py.j2
+++ b/qsg/adapters/templates/azure_submit.py.j2
@@ -24,3 +24,8 @@ job = target.submit(
     input_params={"entryPoint": "ENTRYPOINT__main", "arguments": [], "shots": 8192},
 )
 print("Submitted job:", job.id)
+
+job.wait_until_completed()
+result = job.get_results()
+print(f"Job status: {job.status}")
+print(f"Job result: {result}")

--- a/qsg/ir/lower.py
+++ b/qsg/ir/lower.py
@@ -19,7 +19,24 @@ def lower_to_ir(src_path: str, kind: str):
         return {"program.qasm": dumps(qc)}
 
     elif kind == "qir":
-        # Pass-through for pre-generated QIR bitcode or LLVM IR
-        return {"program.bc": src.read_bytes()}
+        if src.suffix in {".bc", ".ll"}:
+            # Pass-through for pre-generated QIR bitcode or textual LLVM IR
+            return {f"program{src.suffix}": src.read_bytes()}
+
+        if src.suffix == ".py":
+            from qiskit import QuantumCircuit
+            from qiskit_qir import to_qir_module
+
+            scope = {}
+            exec(src.read_text(), scope)
+            if "build_circuit" not in scope:
+                raise ValueError("Expected a build_circuit() function in the source file.")
+            qc = scope["build_circuit"]()
+            if not isinstance(qc, QuantumCircuit):
+                raise TypeError("build_circuit() must return a qiskit.QuantumCircuit.")
+            module, _ = to_qir_module(qc)
+            return {"program.ll": str(module).encode()}
+
+        raise ValueError("QIR input must be a .py, .bc, or .ll file")
     else:
         raise ValueError(f"Unknown IR kind: {kind}")

--- a/qsg/ir/lower.py
+++ b/qsg/ir/lower.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+from qiskit import transpile
+
 
 def lower_to_ir(src_path: str, kind: str):
     src = Path(src_path)
@@ -31,9 +33,14 @@ def lower_to_ir(src_path: str, kind: str):
             exec(src.read_text(), scope)
             if "build_circuit" not in scope:
                 raise ValueError("Expected a build_circuit() function in the source file.")
+
             qc = scope["build_circuit"]()
             if not isinstance(qc, QuantumCircuit):
                 raise TypeError("build_circuit() must return a qiskit.QuantumCircuit.")
+            ALLOWED = ['rx','ry','rz','x','y','z','h','s','sdg','t','tdg',
+           'cx','cz','ccx','swap','id','measure','reset','delay','barrier']
+
+            qc = transpile(qc, basis_gates=ALLOWED, optimization_level=1)
             module, _ = to_qir_module(qc)
             return {"program.ll": str(module).encode()}
 

--- a/tests/test_azure_adapter.py
+++ b/tests/test_azure_adapter.py
@@ -1,0 +1,35 @@
+from qsg.adapters.azure_qir import AzureQIRAdapter
+import pytest
+
+
+def test_entrypoint_uses_default_context():
+    adapter = AzureQIRAdapter()
+    code = adapter.entrypoint()
+    assert '/app/payload/program.bc' in code
+    assert 'target="microsoft.qpu"' in code
+    # ensure authentication env vars are referenced
+    assert 'AZURE_QUANTUM_SUBSCRIPTION_ID' in code
+    assert 'AZURE_QUANTUM_RESOURCE_GROUP' in code
+
+
+def test_entrypoint_accepts_custom_context():
+    adapter = AzureQIRAdapter(payload_path='/tmp/foo.bc', target='quantinuum.qpu')
+    code = adapter.entrypoint()
+    assert '/tmp/foo.bc' in code
+    assert 'quantinuum.qpu' in code
+    assert '/app/payload/program.bc' not in code
+    assert 'microsoft.qpu' not in code
+
+
+def test_entrypoint_missing_required_field():
+    adapter = AzureQIRAdapter(target=None)
+    with pytest.raises(ValueError):
+        adapter.entrypoint()
+
+
+def test_runtime_packages_include_dependencies():
+    adapter = AzureQIRAdapter()
+    pkgs = adapter.runtime_packages()
+    assert 'azure-quantum' in pkgs
+    assert 'azure-identity' in pkgs
+

--- a/tests/test_ir_lower.py
+++ b/tests/test_ir_lower.py
@@ -38,6 +38,39 @@ def test_lower_to_ir_qir(tmp_path):
     assert result == {'program.bc': b'1234'}
 
 
+def test_lower_to_ir_qir_ll(tmp_path):
+    src = tmp_path / 'program.ll'
+    src.write_text('; module')
+    result = lower_to_ir(str(src), 'qir')
+    assert result == {'program.ll': b'; module'}
+
+
+def test_lower_to_ir_qiskit_to_qir(tmp_path):
+    qiskit = types.ModuleType('qiskit')
+    class QuantumCircuit:
+        def __init__(self):
+            self.name = 'test'
+    qiskit.QuantumCircuit = QuantumCircuit
+    sys.modules['qiskit'] = qiskit
+
+    qiskit_qir = types.ModuleType('qiskit_qir')
+    class Module:
+        def __str__(self):
+            return '; qir'
+    def to_qir_module(qc):
+        return Module(), ['main']
+    qiskit_qir.to_qir_module = to_qir_module
+    sys.modules['qiskit_qir'] = qiskit_qir
+
+    src = tmp_path / 'circuit.py'
+    src.write_text('from qiskit import QuantumCircuit\n'
+                   'def build_circuit():\n'
+                   '    return QuantumCircuit()\n')
+
+    result = lower_to_ir(str(src), 'qir')
+    assert result == {'program.ll': b'; qir'}
+
+
 def test_lower_to_ir_unknown(tmp_path):
     src = tmp_path / 'program.txt'
     src.write_text('hello')


### PR DESCRIPTION
## Summary
- add Azure Quantum submission template using DefaultAzureCredential and payload path
- wire Azure QIR adapter to TemplateManager and include azure packages
- cover Azure adapter entrypoint and runtime packages in new tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a91e2327b88333b42229802c7b81b5