### PR TITLE
Add Qiskit circuit transpilation to QIR

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
   "jinja2>=3.1",
   "docker>=7.0",
   "qiskit>=1.0",
+  "qiskit-qir>=0.5",
   "cirq-core>=1.3",
   "qiskit-ibm-runtime>=0.25",
   "pyyaml>=6.0",

--- a/qsg/ir/lower.py
+++ b/qsg/ir/lower.py
@@ -19,7 +19,24 @@ def lower_to_ir(src_path: str, kind: str):
         return {"program.qasm": dumps(qc)}
 
     elif kind == "qir":
-        # Pass-through for pre-generated QIR bitcode or LLVM IR
-        return {"program.bc": src.read_bytes()}
+        if src.suffix in {".bc", ".ll"}:
+            # Pass-through for pre-generated QIR bitcode or textual LLVM IR
+            return {f"program{src.suffix}": src.read_bytes()}
+
+        if src.suffix == ".py":
+            from qiskit import QuantumCircuit
+            from qiskit_qir import to_qir_module
+
+            scope = {}
+            exec(src.read_text(), scope)
+            if "build_circuit" not in scope:
+                raise ValueError("Expected a build_circuit() function in the source file.")
+            qc = scope["build_circuit"]()
+            if not isinstance(qc, QuantumCircuit):
+                raise TypeError("build_circuit() must return a qiskit.QuantumCircuit.")
+            module, _ = to_qir_module(qc)
+            return {"program.ll": str(module).encode()}
+
+        raise ValueError("QIR input must be a .py, .bc, or .ll file")
     else:
         raise ValueError(f"Unknown IR kind: {kind}")

--- a/tests/test_ir_lower.py
+++ b/tests/test_ir_lower.py
@@ -38,6 +38,39 @@ def test_lower_to_ir_qir(tmp_path):
     assert result == {'program.bc': b'1234'}
 
 
+def test_lower_to_ir_qir_ll(tmp_path):
+    src = tmp_path / 'program.ll'
+    src.write_text('; module')
+    result = lower_to_ir(str(src), 'qir')
+    assert result == {'program.ll': b'; module'}
+
+
+def test_lower_to_ir_qiskit_to_qir(tmp_path):
+    qiskit = types.ModuleType('qiskit')
+    class QuantumCircuit:
+        def __init__(self):
+            self.name = 'test'
+    qiskit.QuantumCircuit = QuantumCircuit
+    sys.modules['qiskit'] = qiskit
+
+    qiskit_qir = types.ModuleType('qiskit_qir')
+    class Module:
+        def __str__(self):
+            return '; qir'
+    def to_qir_module(qc):
+        return Module(), ['main']
+    qiskit_qir.to_qir_module = to_qir_module
+    sys.modules['qiskit_qir'] = qiskit_qir
+
+    src = tmp_path / 'circuit.py'
+    src.write_text('from qiskit import QuantumCircuit\n'
+                   'def build_circuit():\n'
+                   '    return QuantumCircuit()\n')
+
+    result = lower_to_ir(str(src), 'qir')
+    assert result == {'program.ll': b'; qir'}
+
+
 def test_lower_to_ir_unknown(tmp_path):
     src = tmp_path / 'program.txt'
     src.write_text('hello')


### PR DESCRIPTION
## Summary
- support transpiling Qiskit Python circuits into textual QIR via `qiskit_qir`
- allow `.py` sources alongside `.bc`/`.ll` pass-through in `lower_to_ir`
- add dependency and unit test for Qiskit-to-QIR lowering

## Testing
- `pytest tests/test_ir_lower.py -q`
- `pytest -q` *(fails: Azure adapter assertion about target and missing `pyyaml` for config parsing)*

------
https://chatgpt.com/codex/tasks/task_e_68abf0becad08333acc98ec7219fdda8